### PR TITLE
Fix V730 warning from PVS-Studio Static Analyzer

### DIFF
--- a/libyzis/action.cpp
+++ b/libyzis/action.cpp
@@ -29,7 +29,7 @@
 #define dbg()    yzDebug("YZAction")
 #define err()    yzError("YZAction")
 
-YZAction::YZAction( YBuffer* buffer )
+YZAction::YZAction( YBuffer* buffer ) : mPos(NULL)
 {
     dbg() << "YZAction(" << buffer->toString() << ")" << endl;
     mBuffer = buffer;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
Not all members of a class are initialized inside the constructor.
Consider inspecting: mPos.