### PR TITLE
Fix V614 warning from PVS-Studio Static Analyzer

### DIFF
--- a/libyzis/mode_command.cpp
+++ b/libyzis/mode_command.cpp
@@ -525,7 +525,7 @@ YCursor YModeCommand::percentCommand(const YMotionArgs &args, CmdState *state, M
     {
         newCursorPos.setLineColumn(cursorBefore.line(), pos);
         int nOpen=0 , nClose=0;
-        int maxLine , l = newCursorPos.line();  
+        int maxLine=0 , l = newCursorPos.line();
         int direction; // Match forward or backwards ?
         QChar ch = line[newCursorPos.column()] , correspondingCh;
         // If it is an opening character (like (, [ ...), go to the closing character


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
Potentially uninitialized variable 'maxLine' used.