### PR TITLE
Fix V501 warning from PVS-Studio Static Analyzer

### DIFF
--- a/libyzis/action.cpp
+++ b/libyzis/action.cpp
@@ -275,7 +275,7 @@ void YZAction::mergeNextLine( YView* pView, int y, bool stripSpaces )
     QString line2 = mBuffer->textline( y + 1 );
     if ( stripSpaces ) {
         QString space(" ");
-        if ( line.endsWith(" ") || line.endsWith(" ") )
+        if ( line.endsWith(" ") )
             space = "";
         line2.replace(QRegExp("^\\s*"), space);
     }


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
There are identical sub-expressions to the left and to the right
of the '||' operator: line.endsWith(" ") || line.endsWith(" ")